### PR TITLE
:construction_worker: : use node 12 for percy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
 env:
   global:
     - MOZ_HEADLESS=1
+    - NODE_VERSION=12
 
 cache:
   directories:
@@ -43,6 +44,7 @@ jobs:
       if: env(PERCY_TOKEN) AND ( type = pull_request OR branch = master )
       install: skip
       script:
+      - nvm install $NODE_VERSION && nvm use $NODE_VERSION
       # searching for the 'no-percy' label on the PR, if it is found, do not run percy :)
       - echo "checking is percy is enabled on PR $TRAVIS_PULL_REQUEST"
       - NO_PERCY=$(curl -s https://api.github.com/repos/gaia-app/gaia/pulls/$TRAVIS_PULL_REQUEST | jq '.labels[].name | select(.=="no-percy")' | tr -d \")


### PR DESCRIPTION
as puppeteer (needed by percy), since 3.0 needs node 10.18.1+ (default node on travis-ci is 8.16)

this will restore broken builds :)