### PR TITLE
⚡ : integration test performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ jobs:
   include:
     - stage: test
       name: "Unit Tests"
+      install: skip
       script:
       # fetching master refs when building other branches helps sonar computing PRs
       - git fetch origin +refs/heads/master:refs/remotes/origin/master

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       # fetching master refs when building other branches helps sonar computing PRs
       - git fetch origin +refs/heads/master:refs/remotes/origin/master
       # the following command line builds the project, runs the tests with coverage and then execute the SonarCloud analysis
-      - mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar
+      - mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar -DexcludedGroups=e2e -P ci-tu
     - stage: test
       name: "Visual Non Regression Tests"
       if: env(PERCY_TOKEN) AND ( type = pull_request OR branch = master )

--- a/pom.xml
+++ b/pom.xml
@@ -347,4 +347,34 @@
 
     </build>
 
+    <profiles>
+        <profile>
+            <!-- skiping npm install / build when running unit tests -->
+            <id>ci-tu</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>${frontend-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>install node and npm</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>npm install</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>vue build</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/src/test/java/io/gaia_app/GaiaIT.java
+++ b/src/test/java/io/gaia_app/GaiaIT.java
@@ -1,21 +1,14 @@
 package io.gaia_app;
 
-import io.gaia_app.test.MongoContainer;
-import io.gaia_app.test.MongoContainer;
+import io.gaia_app.test.SharedMongoContainerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
-@Testcontainers
-class GaiaIT {
-
-	@Container
-	private static MongoContainer mongoContainer = new MongoContainer();
+class GaiaIT extends SharedMongoContainerTest {
 
 	@Autowired
 	private Gaia gaia;

--- a/src/test/java/io/gaia_app/client/controller/AuthenticationRestControllerIT.kt
+++ b/src/test/java/io/gaia_app/client/controller/AuthenticationRestControllerIT.kt
@@ -1,35 +1,33 @@
 package io.gaia_app.client.controller
 
-import io.gaia_app.test.MongoContainer
+import io.gaia_app.test.SharedMongoContainerTest
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
 @SpringBootTest
-@DirtiesContext
-@Testcontainers
 @AutoConfigureMockMvc
-class AuthenticationRestControllerIT {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AuthenticationRestControllerIT: SharedMongoContainerTest() {
 
     @Autowired
     lateinit var mockMvc: MockMvc
 
-    companion object {
-        @Container
-        val mongoContainer = MongoContainer()
-            .withScript("src/test/resources/db/00_team.js")
-            .withScript("src/test/resources/db/10_user.js")
+    @BeforeAll
+    fun setUp() {
+        mongo.emptyDatabase()
+        mongo.runScript("src/test/resources/db/00_team.js")
+        mongo.runScript("src/test/resources/db/10_user.js")
     }
 
     @Test

--- a/src/test/java/io/gaia_app/config/security/SecurityConfigIT.kt
+++ b/src/test/java/io/gaia_app/config/security/SecurityConfigIT.kt
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @SpringBootTest(classes = [SecurityConfig::class, SecurityConfigIT.FakeRestController::class])
 @AutoConfigureMockMvc
-@DirtiesContext
 @TestPropertySource(properties = ["gaia.admin-password=admin456"])
 class SecurityConfigIT {
 

--- a/src/test/java/io/gaia_app/config/security/StateApiSecurityConfigIT.java
+++ b/src/test/java/io/gaia_app/config/security/StateApiSecurityConfigIT.java
@@ -1,14 +1,11 @@
 package io.gaia_app.config.security;
 
-import io.gaia_app.test.MongoContainer;
+import io.gaia_app.test.SharedMongoContainerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
@@ -18,12 +15,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DirtiesContext
-@Testcontainers
-public class StateApiSecurityConfigIT {
-
-    @Container
-    private static MongoContainer mongoContainer = new MongoContainer();
+public class StateApiSecurityConfigIT extends SharedMongoContainerTest {
 
     @Autowired
     private StateApiSecurityConfig.StateApiSecurityProperties props;

--- a/src/test/java/io/gaia_app/config/security/actuator/ActuatorSecurityConfigIT.java
+++ b/src/test/java/io/gaia_app/config/security/actuator/ActuatorSecurityConfigIT.java
@@ -1,14 +1,11 @@
 package io.gaia_app.config.security.actuator;
 
-import io.gaia_app.test.MongoContainer;
+import io.gaia_app.test.SharedMongoContainerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,15 +15,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DirtiesContext
-@Testcontainers
-class ActuatorSecurityConfigIT {
+class ActuatorSecurityConfigIT extends SharedMongoContainerTest {
 
     @Autowired
     private MockMvc mockMvc;
-
-    @Container
-    private static MongoContainer mongo = new MongoContainer();
 
     @Test
     void actuatorHealth_shouldNotNeedAuthentication() throws Exception {

--- a/src/test/java/io/gaia_app/config/security/ldap/LdapSecurityConfigIT.java
+++ b/src/test/java/io/gaia_app/config/security/ldap/LdapSecurityConfigIT.java
@@ -1,27 +1,21 @@
 package io.gaia_app.config.security.ldap;
 
-import io.gaia_app.test.MongoContainer;
+import io.gaia_app.test.SharedMongoContainerTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@DirtiesContext
 @Testcontainers
 class LdapSecurityConfigIT {
 
-    @Container
-    private static MongoContainer mongoContainer = new MongoContainer();
-
     @Nested
     @SpringBootTest(properties = "gaia.ldap.enabled=false")
-    class LdapSecurityConfigNotLoadedTest {
+    class LdapSecurityConfigNotLoadedTest extends SharedMongoContainerTest {
         @Test
         void ldapSecurityConfig_shouldNotBeInstantiated(
                 @Autowired(required = false) LdapSecurityConfig ldapSecurityConfig) {
@@ -35,7 +29,7 @@ class LdapSecurityConfigIT {
             "gaia.ldap.userDnPatterns=test_dn",
             "gaia.ldap.url=ldap://test_url",
     })
-    class LdapSecurityConfigLoadedTest {
+    class LdapSecurityConfigLoadedTest extends SharedMongoContainerTest {
         @Test
         void ldapSecurityConfig_shouldBeInstantiated(
                 @Autowired(required = false) LdapSecurityConfig ldapSecurityConfig) {

--- a/src/test/java/io/gaia_app/config/security/oauth2/OAuth2ClientSecurityConfigIT.kt
+++ b/src/test/java/io/gaia_app/config/security/oauth2/OAuth2ClientSecurityConfigIT.kt
@@ -1,6 +1,6 @@
 package io.gaia_app.config.security.oauth2
 
-import io.gaia_app.test.MongoContainer
+import io.gaia_app.test.SharedMongoContainerTest
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Nested
@@ -8,27 +8,17 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
-@DirtiesContext
-@Testcontainers
 class OAuth2ClientSecurityConfigIT {
-
-    companion object {
-        @Container
-        val mongoContainer = MongoContainer()
-    }
 
     @Nested
     @SpringBootTest
-    inner class OAuth2ClientSecurityConfigNotLoadedTest {
+    inner class OAuth2ClientSecurityConfigNotLoadedTest: SharedMongoContainerTest() {
 
         @Test
         fun `oauth2ClientSecurityConfig should not be instantiated`(
@@ -47,7 +37,7 @@ class OAuth2ClientSecurityConfigIT {
     @Nested
     @SpringBootTest
     @ActiveProfiles("oauth2")
-    inner class OAuth2ClientSecurityConfigLoadedTest {
+    inner class OAuth2ClientSecurityConfigLoadedTest: SharedMongoContainerTest() {
 
         @Test
         fun `oauth2ClientSecurityConfig should be instantiated`(
@@ -75,7 +65,7 @@ class OAuth2ClientSecurityConfigIT {
         "spring.security.oauth2.client.provider.dummy.token-uri=https://dummy.com/oauth/token",
         "spring.security.oauth2.client.provider.dummy.user-info-uri=https://dummy.com/api/v4/user",
         "spring.security.oauth2.client.provider.dummy.user-name-attribute=username"])
-    inner class OAuth2ClientSecurityTest {
+    inner class OAuth2ClientSecurityTest: SharedMongoContainerTest() {
 
         @Autowired
         lateinit var mockMvc: MockMvc

--- a/src/test/java/io/gaia_app/e2e/SeleniumIT.java
+++ b/src/test/java/io/gaia_app/e2e/SeleniumIT.java
@@ -1,7 +1,6 @@
 package io.gaia_app.e2e;
 
-import io.gaia_app.test.MongoContainer;
-import io.gaia_app.test.MongoContainer;
+import io.gaia_app.test.SharedMongoContainerTest;
 import io.percy.selenium.Percy;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.*;
@@ -15,9 +14,6 @@ import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.pagefactory.AjaxElementLocatorFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.annotation.DirtiesContext;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,24 +23,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext
-@Testcontainers
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Tag("e2e")
-public class SeleniumIT {
+public class SeleniumIT extends SharedMongoContainerTest {
 
     @LocalServerPort
     private int serverPort;
-
-    @Container
-    private static MongoContainer mongoContainer = new MongoContainer()
-            .withScript("src/test/resources/db/00_team.js")
-            .withScript("src/test/resources/db/10_user.js")
-            .withScript("src/test/resources/db/20_module.js")
-            .withScript("src/test/resources/db/30_stack.js")
-            .withScript("src/test/resources/db/40_job.js")
-            .withScript("src/test/resources/db/50_step.js")
-            .withScript("src/test/resources/db/60_terraformState.js");
 
     private static WebDriver driver;
 
@@ -65,6 +49,15 @@ public class SeleniumIT {
         percy = new Percy(driver);
 
         driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        mongo.emptyDatabase();
+        mongo.runScript("src/test/resources/db/00_team.js");
+        mongo.runScript("src/test/resources/db/10_user.js");
+        mongo.runScript("src/test/resources/db/20_module.js");
+        mongo.runScript("src/test/resources/db/30_stack.js");
+        mongo.runScript("src/test/resources/db/40_job.js");
+        mongo.runScript("src/test/resources/db/50_step.js");
+        mongo.runScript("src/test/resources/db/60_terraformState.js");
     }
 
     @AfterAll

--- a/src/test/java/io/gaia_app/modules/controller/DockerRegistryRestControllerIT.kt
+++ b/src/test/java/io/gaia_app/modules/controller/DockerRegistryRestControllerIT.kt
@@ -1,8 +1,10 @@
 package io.gaia_app.modules.controller;
 
-import io.gaia_app.test.MongoContainer
+import io.gaia_app.test.SharedMongoContainerTest
 import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -10,7 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.core.io.ClassPathResource
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.client.MockRestServiceServer.bindTo
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
@@ -19,15 +20,12 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.web.client.RestTemplate
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
 @SpringBootTest
-@DirtiesContext
-@Testcontainers
 @AutoConfigureWebClient
 @AutoConfigureMockMvc
-class DockerRegistryRestControllerIT {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DockerRegistryRestControllerIT: SharedMongoContainerTest() {
 
     @Autowired
     lateinit var mockMvc: MockMvc
@@ -35,9 +33,10 @@ class DockerRegistryRestControllerIT {
     @Autowired
     lateinit var restTemplate: RestTemplate
 
-    companion object {
-        @Container
-        val mongoContainer = MongoContainer().withScript("src/test/resources/db/10_user.js")
+    @BeforeAll
+    internal fun setUp() {
+        mongo.emptyDatabase()
+        mongo.runScript("src/test/resources/db/10_user.js")
     }
 
     @Test

--- a/src/test/java/io/gaia_app/modules/controller/ModuleRestControllerIT.java
+++ b/src/test/java/io/gaia_app/modules/controller/ModuleRestControllerIT.java
@@ -1,6 +1,6 @@
 package io.gaia_app.modules.controller;
 
-import io.gaia_app.test.MongoContainer;
+import io.gaia_app.test.SharedMongoContainerTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,10 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.hamcrest.Matchers.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -24,24 +21,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Simple integration test that validates the security configuration of the TeamsRestController, and its http routes
  */
 @SpringBootTest
-@DirtiesContext
-@Testcontainers
 @AutoConfigureMockMvc
 @WithMockUser(value = "admin", roles = "ADMIN")
-class ModuleRestControllerIT {
-
-    @Container
-    private static MongoContainer mongoContainer = new MongoContainer()
-            .withScript("src/test/resources/db/00_team.js")
-            .withScript("src/test/resources/db/10_user.js")
-            .withScript("src/test/resources/db/20_module.js");
+class ModuleRestControllerIT extends SharedMongoContainerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
     @BeforeEach
     void setup() {
-        mongoContainer.resetDatabase();
+        mongo.emptyDatabase();
+        mongo.runScript("src/test/resources/db/00_team.js");
+        mongo.runScript("src/test/resources/db/10_user.js");
+        mongo.runScript("src/test/resources/db/20_module.js");
     }
 
     @Test

--- a/src/test/java/io/gaia_app/modules/repository/TerraformModuleRepositoryIT.java
+++ b/src/test/java/io/gaia_app/modules/repository/TerraformModuleRepositoryIT.java
@@ -3,30 +3,18 @@ package io.gaia_app.modules.repository;
 import io.gaia_app.modules.bo.TerraformModule;
 import io.gaia_app.teams.Team;
 import io.gaia_app.teams.User;
-import io.gaia_app.test.MongoContainer;
-import io.gaia_app.modules.bo.TerraformModule;
-import io.gaia_app.teams.Team;
-import io.gaia_app.teams.User;
-import io.gaia_app.test.MongoContainer;
+import io.gaia_app.test.SharedMongoContainerTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataMongoTest
-@Testcontainers
-@DirtiesContext
-class TerraformModuleRepositoryIT {
-
-    @Container
-    private static MongoContainer mongoContainer = new MongoContainer();
+class TerraformModuleRepositoryIT extends SharedMongoContainerTest {
 
     @Autowired
     private TerraformModuleRepository terraformModuleRepository;

--- a/src/test/java/io/gaia_app/registries/controller/GithubRegistryControllerIT.kt
+++ b/src/test/java/io/gaia_app/registries/controller/GithubRegistryControllerIT.kt
@@ -7,8 +7,9 @@ import io.gaia_app.registries.RegistryDetails
 import io.gaia_app.registries.RegistryType
 import io.gaia_app.teams.OAuth2User
 import io.gaia_app.teams.User
-import io.gaia_app.test.MongoContainer
+import io.gaia_app.test.SharedMongoContainerTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient
@@ -17,7 +18,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.core.io.ClassPathResource
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.client.MockRestServiceServer
 import org.springframework.test.web.client.match.MockRestRequestMatchers
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
@@ -27,16 +27,12 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.web.client.RestTemplate
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 import java.time.LocalDateTime
 
 @SpringBootTest
-@DirtiesContext
-@Testcontainers
 @AutoConfigureWebClient
 @AutoConfigureMockMvc
-class GithubRegistryControllerIT {
+class GithubRegistryControllerIT: SharedMongoContainerTest() {
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
@@ -50,13 +46,14 @@ class GithubRegistryControllerIT {
     @Autowired
     private lateinit var mockMvc: MockMvc
 
-    companion object {
-        @Container
-        private val mongoContainer = MongoContainer().withScript("src/test/resources/db/10_user.js")
-    }
-
     @Autowired
     private lateinit var githubRegistryController: GithubRegistryController
+
+    @BeforeEach
+    internal fun setUp() {
+        mongo.emptyDatabase()
+        mongo.runScript("src/test/resources/db/10_user.js")
+    }
 
     @Test
     fun validateTestConfiguration() {

--- a/src/test/java/io/gaia_app/registries/controller/GitlabRegistryControllerIT.kt
+++ b/src/test/java/io/gaia_app/registries/controller/GitlabRegistryControllerIT.kt
@@ -7,8 +7,9 @@ import io.gaia_app.registries.RegistryDetails
 import io.gaia_app.registries.RegistryType
 import io.gaia_app.teams.OAuth2User
 import io.gaia_app.teams.User
-import io.gaia_app.test.MongoContainer
+import io.gaia_app.test.SharedMongoContainerTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient
@@ -17,7 +18,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.core.io.ClassPathResource
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.client.MockRestServiceServer
 import org.springframework.test.web.client.match.MockRestRequestMatchers
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
@@ -26,16 +26,12 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.web.client.RestTemplate
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 import java.time.LocalDateTime
 
 @SpringBootTest
-@DirtiesContext
-@Testcontainers
 @AutoConfigureWebClient
 @AutoConfigureMockMvc
-class GitlabRegistryControllerIT {
+class GitlabRegistryControllerIT: SharedMongoContainerTest() {
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
@@ -49,13 +45,14 @@ class GitlabRegistryControllerIT {
     @Autowired
     private lateinit var mockMvc: MockMvc
 
-    companion object {
-        @Container
-        private val mongoContainer = MongoContainer().withScript("src/test/resources/db/10_user.js")
-    }
-
     @Autowired
     private lateinit var gitlabRegistryController: GitlabRegistryController
+
+    @BeforeEach
+    internal fun setUp() {
+        mongo.emptyDatabase()
+        mongo.runScript("src/test/resources/db/10_user.js")
+    }
 
     @Test
     fun validateTestConfiguration() {

--- a/src/test/java/io/gaia_app/settings/repository/SettingsRepositoryIT.java
+++ b/src/test/java/io/gaia_app/settings/repository/SettingsRepositoryIT.java
@@ -1,28 +1,19 @@
 package io.gaia_app.settings.repository;
 
 import io.gaia_app.settings.bo.Settings;
-import io.gaia_app.test.MongoContainer;
-import io.gaia_app.test.MongoContainer;
+import io.gaia_app.test.SharedMongoContainerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-@Testcontainers
 @TestPropertySource(properties = {"gaia.externalUrl=http://gaia.io", "gaia.dockerDaemonUrl=unix:///var/run/docker.sock"})
-@DirtiesContext
-class SettingsRepositoryIT {
-
-    @Container
-    private static MongoContainer mongoContainer = new MongoContainer();
+class SettingsRepositoryIT extends SharedMongoContainerTest {
 
     @Autowired
     private MongoTemplate mongoTemplate;

--- a/src/test/java/io/gaia_app/stacks/controller/StackRestControllerIT.java
+++ b/src/test/java/io/gaia_app/stacks/controller/StackRestControllerIT.java
@@ -1,7 +1,6 @@
 package io.gaia_app.stacks.controller;
 
-import io.gaia_app.test.MongoContainer;
-import io.gaia_app.test.MongoContainer;
+import io.gaia_app.test.SharedMongoContainerTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,10 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.hamcrest.Matchers.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -24,164 +20,159 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Simple integration test that validates the security configuration of the TeamsRestController, and its http routes
  */
 @SpringBootTest
-@DirtiesContext
-@Testcontainers
 @AutoConfigureMockMvc
 @WithMockUser(value = "admin", roles = "ADMIN")
-class StackRestControllerIT {
-
-    @Container
-    private static MongoContainer mongoContainer = new MongoContainer()
-            .withScript("src/test/resources/db/00_team.js")
-            .withScript("src/test/resources/db/10_user.js")
-            .withScript("src/test/resources/db/20_module.js")
-            .withScript("src/test/resources/db/30_stack.js");
+class StackRestControllerIT extends SharedMongoContainerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
     @BeforeEach
-    void setup() {
-        mongoContainer.resetDatabase();
+    void setUp() {
+        mongo.emptyDatabase();
+        mongo.runScript("src/test/resources/db/00_team.js");
+        mongo.runScript("src/test/resources/db/10_user.js");
+        mongo.runScript("src/test/resources/db/20_module.js");
+        mongo.runScript("src/test/resources/db/30_stack.js");
     }
 
     @Test
     @WithMockUser("Mary J")
     void listStacks_shouldReturnLimitedStacks_forStandardUsers() throws Exception {
         mockMvc.perform(get("/api/stacks"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(1)))
-                .andExpect(jsonPath("$[0]name", is("mongo-instance-limited")))
-                .andExpect(jsonPath("$[0]ownerTeam.id", is("Not Ze Team")));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(1)))
+            .andExpect(jsonPath("$[0]name", is("mongo-instance-limited")))
+            .andExpect(jsonPath("$[0]ownerTeam.id", is("Not Ze Team")));
     }
 
     @Test
     void listStacks_shouldReturnAllStacks_forAdmin() throws Exception {
         mockMvc.perform(get("/api/stacks"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(4)))
-                .andExpect(jsonPath("$..name", contains("mongo-instance-1", "mongo-instance-2", "mongo-instance-limited", "local-mongo")))
-                .andExpect(jsonPath("$..ownerTeam.id", contains("Ze Team", "Ze Team", "Not Ze Team")));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(4)))
+            .andExpect(jsonPath("$..name", contains("mongo-instance-1", "mongo-instance-2", "mongo-instance-limited", "local-mongo")))
+            .andExpect(jsonPath("$..ownerTeam.id", contains("Ze Team", "Ze Team", "Not Ze Team")));
     }
 
     @Test
     @WithMockUser("Mary J")
     void getStacks_shouldReturnStack_forStandardUsers() throws Exception {
         mockMvc.perform(get("/api/stacks/845543d0-20a5-466c-8978-33c9a4661606"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name", is("mongo-instance-limited")))
-                .andExpect(jsonPath("$.ownerTeam.id", is("Not Ze Team")))
-                .andExpect(jsonPath("$.estimatedRunningCost", is(0)));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.name", is("mongo-instance-limited")))
+            .andExpect(jsonPath("$.ownerTeam.id", is("Not Ze Team")))
+            .andExpect(jsonPath("$.estimatedRunningCost", is(0)));
     }
 
     @Test
     @WithMockUser("Mary J")
     void getStacks_shouldNotReturnStackOfOtherTeams_forStandardUsers() throws Exception {
         mockMvc.perform(get("/api/stacks/5a215b6b-fe53-4afa-85f0-a10175a7f264"))
-                .andExpect(status().isNotFound());
+            .andExpect(status().isNotFound());
     }
 
     @Test
     void getStacks_shouldReturnStack_forAdmin() throws Exception {
         mockMvc.perform(get("/api/stacks/5a215b6b-fe53-4afa-85f0-a10175a7f264"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name", is("mongo-instance-1")))
-                .andExpect(jsonPath("$.ownerTeam.id", is("Ze Team")))
-                .andExpect(jsonPath("$.estimatedRunningCost", is(0)));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.name", is("mongo-instance-1")))
+            .andExpect(jsonPath("$.ownerTeam.id", is("Ze Team")))
+            .andExpect(jsonPath("$.estimatedRunningCost", is(0)));
     }
 
     @Test
     @WithMockUser("Mary J")
     void saveStack_shouldBeAccessible_forStandardUser() throws Exception {
         mockMvc.perform(post("/api/stacks")
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"stack-test\", \"moduleId\": \"e01f9925-a559-45a2-8a55-f93dc434c676\"}"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id", notNullValue()))
-                .andExpect(jsonPath("$.ownerTeam.id", is("Not Ze Team")))
-                .andExpect(jsonPath("$.createdBy.username", is("Mary J")))
-                .andExpect(jsonPath("$.createdAt", notNullValue()));
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"stack-test\", \"moduleId\": \"e01f9925-a559-45a2-8a55-f93dc434c676\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id", notNullValue()))
+            .andExpect(jsonPath("$.ownerTeam.id", is("Not Ze Team")))
+            .andExpect(jsonPath("$.createdBy.username", is("Mary J")))
+            .andExpect(jsonPath("$.createdAt", notNullValue()));
     }
 
     @Test
     @WithMockUser("Mary J")
     void updateStack_shouldBeAccessible_forStandardUser() throws Exception {
         mockMvc.perform(put("/api/stacks/test")
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"stack-test\", \"moduleId\": \"e01f9925-a559-45a2-8a55-f93dc434c676\"}"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.updatedBy.username", is("Mary J")))
-                .andExpect(jsonPath("$.updatedAt", notNullValue()));
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"stack-test\", \"moduleId\": \"e01f9925-a559-45a2-8a55-f93dc434c676\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.updatedBy.username", is("Mary J")))
+            .andExpect(jsonPath("$.updatedAt", notNullValue()));
     }
 
     @Test
     void saveStack_shouldValidateStackContent() throws Exception {
         mockMvc.perform(post("/api/stacks")
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                // empty name and module id
-                .content("{}"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", containsString("name must not be blank")))
-                .andExpect(jsonPath("$.message", containsString("moduleId must not be blank")));
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            // empty name and module id
+            .content("{}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message", containsString("name must not be blank")))
+            .andExpect(jsonPath("$.message", containsString("moduleId must not be blank")));
     }
 
     @Test
     void saveStack_shouldValidateStackContent_forBlankFields() throws Exception {
         mockMvc.perform(post("/api/stacks")
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                // empty name and module id
-                .content("{\"name\":\"      \",\"moduleId\":\"   \"}"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", containsString("name must not be blank")))
-                .andExpect(jsonPath("$.message", containsString("moduleId must not be blank")));
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            // empty name and module id
+            .content("{\"name\":\"      \",\"moduleId\":\"   \"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message", containsString("name must not be blank")))
+            .andExpect(jsonPath("$.message", containsString("moduleId must not be blank")));
     }
 
     @Test
     void updateStack_shouldValidateStackContent() throws Exception {
         mockMvc.perform(put("/api/stacks/test")
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                // empty name and module id
-                .content("{\"name\":\"\", \"moduleId\": \"\"}"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", containsString("name must not be blank")))
-                .andExpect(jsonPath("$.message", containsString("moduleId must not be blank")));
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            // empty name and module id
+            .content("{\"name\":\"\", \"moduleId\": \"\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message", containsString("name must not be blank")))
+            .andExpect(jsonPath("$.message", containsString("moduleId must not be blank")));
     }
 
     @Test
     void saveStack_shouldValidateStackVariables() throws Exception {
         mockMvc.perform(post("/api/stacks")
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                // null variable
-                .content("{\"name\":\"stack-test\", \"moduleId\": \"b39ccd07-80f5-455f-a6b3-b94f915738c4\", \"variableValues\":{}}"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", is("mandatory variables should not be blank")));
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            // null variable
+            .content("{\"name\":\"stack-test\", \"moduleId\": \"b39ccd07-80f5-455f-a6b3-b94f915738c4\", \"variableValues\":{}}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message", is("mandatory variables should not be blank")));
     }
 
     @Test
     void saveStack_shouldWork_stackIsValid() throws Exception {
         mockMvc.perform(post("/api/stacks")
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                // empty name
-                .content("{\"name\":\"stack-test\", \"moduleId\": \"b39ccd07-80f5-455f-a6b3-b94f915738c4\", \"variableValues\":{\"mongo_container_name\":\"someContainerName\"}}"))
-                .andExpect(status().isOk());
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            // empty name
+            .content("{\"name\":\"stack-test\", \"moduleId\": \"b39ccd07-80f5-455f-a6b3-b94f915738c4\", \"variableValues\":{\"mongo_container_name\":\"someContainerName\"}}"))
+            .andExpect(status().isOk());
     }
 
     @Test
     void saveStack_shouldValidateStackVariablesRegex() throws Exception {
         mockMvc.perform(post("/api/stacks")
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                // null variable
-                .content("{\"name\":\"stack-test\", \"moduleId\": \"b39ccd07-80f5-455f-a6b3-b94f915738c4\", \"variableValues\":{\"mongo_container_name\":\"someContainerName\",\"mongo_exposed_port\":\"toto\"}}"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", is("variables should match the regex")));
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            // null variable
+            .content("{\"name\":\"stack-test\", \"moduleId\": \"b39ccd07-80f5-455f-a6b3-b94f915738c4\", \"variableValues\":{\"mongo_container_name\":\"someContainerName\",\"mongo_exposed_port\":\"toto\"}}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message", is("variables should match the regex")));
     }
 
 }

--- a/src/test/java/io/gaia_app/stacks/repository/StackRepositoryIT.java
+++ b/src/test/java/io/gaia_app/stacks/repository/StackRepositoryIT.java
@@ -3,14 +3,11 @@ package io.gaia_app.stacks.repository;
 import io.gaia_app.stacks.bo.Stack;
 import io.gaia_app.stacks.bo.StackState;
 import io.gaia_app.teams.Team;
-import io.gaia_app.test.MongoContainer;
+import io.gaia_app.test.SharedMongoContainerTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
 
@@ -19,15 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 @DataMongoTest
-@Testcontainers
-@DirtiesContext
-class StackRepositoryIT {
+class StackRepositoryIT extends SharedMongoContainerTest {
 
     @Autowired
     StackRepository stackRepository;
-
-    @Container
-    private static MongoContainer mongo = new MongoContainer();
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/io/gaia_app/stacks/repository/StepRepositoryIT.java
+++ b/src/test/java/io/gaia_app/stacks/repository/StepRepositoryIT.java
@@ -3,18 +3,11 @@ package io.gaia_app.stacks.repository;
 import io.gaia_app.stacks.bo.Step;
 import io.gaia_app.stacks.bo.StepStatus;
 import io.gaia_app.stacks.bo.StepType;
-import io.gaia_app.test.MongoContainer;
-import io.gaia_app.stacks.bo.Step;
-import io.gaia_app.stacks.bo.StepStatus;
-import io.gaia_app.stacks.bo.StepType;
-import io.gaia_app.test.MongoContainer;
+import io.gaia_app.test.SharedMongoContainerTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 
@@ -22,15 +15,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataMongoTest
-@Testcontainers
-@DirtiesContext
-class StepRepositoryIT {
+class StepRepositoryIT extends SharedMongoContainerTest {
 
     @Autowired
     StepRepository stepRepository;
-
-    @Container
-    private static MongoContainer mongo = new MongoContainer();
 
     @Test
     void jobShouldBeSavedWithLogs() throws IOException {

--- a/src/test/java/io/gaia_app/teams/repository/UserRepositoryIT.kt
+++ b/src/test/java/io/gaia_app/teams/repository/UserRepositoryIT.kt
@@ -2,27 +2,17 @@ package io.gaia_app.teams.repository
 
 import io.gaia_app.teams.Team
 import io.gaia_app.teams.User
-import io.gaia_app.test.MongoContainer
+import io.gaia_app.test.SharedMongoContainerTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
-import org.springframework.test.annotation.DirtiesContext
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
 @DataMongoTest
-@Testcontainers
-@DirtiesContext
-class UserRepositoryIT {
+class UserRepositoryIT: SharedMongoContainerTest() {
 
     @Autowired
     lateinit var userRepository: UserRepository
-
-    companion object {
-        @Container
-        val mongoContainer = MongoContainer()
-    }
 
     @Test
     fun user_shouldBeSaved() {

--- a/src/test/java/io/gaia_app/test/MongoContainer.java
+++ b/src/test/java/io/gaia_app/test/MongoContainer.java
@@ -11,9 +11,7 @@ import org.testcontainers.containers.GenericContainer;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A helper class to start a mongodb container
@@ -23,28 +21,12 @@ public class MongoContainer extends GenericContainer {
     private static final Logger LOG = LoggerFactory.getLogger(MongoContainer.class);
     private static final int MONGO_PORT = 27017;
 
-    private final List<String> scripts = new ArrayList<>();
     private MongoClient client;
     private MongoDatabase database;
 
     public MongoContainer() {
         super("mongo:4.0");
         setExposedPorts(List.of(MONGO_PORT));
-    }
-
-    public MongoContainer withScript(String resource) {
-        scripts.add(resource);
-        return this;
-    }
-
-    @Override
-    public void start() {
-        super.start();
-        var mappedPort = getMappedPort(MONGO_PORT);
-        // register the port as property for spring
-        System.setProperty("gaia.mongodb.uri", String.format("mongodb://localhost:%d/gaia", mappedPort));
-
-        resetDatabase();
     }
 
     public MongoClient getClient() {
@@ -55,7 +37,7 @@ public class MongoContainer extends GenericContainer {
     }
 
     public String connectionURL(){
-        return String.format("mongodb://%s:%d",this.getContainerIpAddress(), getMappedPort(MONGO_PORT));
+        return String.format("mongodb://%s:%d/gaia",this.getContainerIpAddress(), getMappedPort(MONGO_PORT));
     }
 
     public MongoDatabase getDatabase() {
@@ -65,22 +47,19 @@ public class MongoContainer extends GenericContainer {
         return database;
     }
 
-    public void resetDatabase() {
-        var nbScripts = scripts.stream()
-                .map(script -> {
-                    try (final FileInputStream fis = new FileInputStream(script)) {
-                        return IOUtils.toString(fis, "UTF-8");
-                    } catch (IOException e) {
-                        LOG.warn("Unable to read file: {} skipped.", script);
-                        return null;
-                    }
-                })
-                .filter(Objects::nonNull)
-                .map(content -> new Document("$eval", content))
-                .map(getDatabase()::runCommand)
-                .count();
+    public void runScript(String resource){
+        try (final FileInputStream fis = new FileInputStream(resource)) {
+            var content = IOUtils.toString(fis, "UTF-8");
 
-        LOG.info("Number of scripts executed: {}", nbScripts);
+            var document = new Document("$eval", content);
+
+            getDatabase().runCommand(document);
+        } catch (IOException e) {
+            LOG.warn("Unable to read file: {} skipped.", resource);
+        }
     }
 
+    public void emptyDatabase() {
+        getDatabase().drop();
+    }
 }

--- a/src/test/java/io/gaia_app/test/SharedMongoContainerTest.java
+++ b/src/test/java/io/gaia_app/test/SharedMongoContainerTest.java
@@ -1,0 +1,19 @@
+package io.gaia_app.test;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+public abstract class SharedMongoContainerTest {
+
+    protected static MongoContainer mongo = new MongoContainer();
+
+    static {
+        mongo.start();
+    }
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("gaia.mongodb.uri", mongo::connectionURL);
+    }
+
+}


### PR DESCRIPTION
travis-ci builds take between 9 and 13 minutes.

this PR has has taken only 6 minutes to build.

optimizations made :
* share the spring context and testcontainers database between integration tests
  * remove @DirtiesContext annotation
  * create a parent class for shared container instances
  * update MongoContainer methods to empty database
* create a maven profile not to build the front when running tests
* skip the default 'mvn install' made by travis, as it is done twice