### PR TITLE
🐛 : add exit 0 at the end of scripts

### DIFF
--- a/src/main/resources/mustache/terraform.mustache
+++ b/src/main/resources/mustache/terraform.mustache
@@ -22,3 +22,5 @@ echo 'terraform {
 terraform version
 terraform init
 {{&command}}
+
+exit 0


### PR DESCRIPTION
Some containers do not seem to end well.
So adding an exit 0 command at the end of the script to be sure
that the script ends correctly