### PR TITLE
🚨 : correct linter warning

### DIFF
--- a/src/main/client/app/pages/stacks/stack-creation.vue
+++ b/src/main/client/app/pages/stacks/stack-creation.vue
@@ -147,7 +147,6 @@
         .filter((cred) => cred.provider === this.module.mainProvider)
         .map((cred) => ({ value: cred.id, text: cred.name }));
 
-
       this.stack.moduleId = this.module.id;
       this.stack.variableValues = {};
       this.stack.variables = this.module.variables.map((variable) => ({


### PR DESCRIPTION
There was a linter warning in the PR #353 that prevents CI to pass, even on master branch.