### PR TITLE
✨ : support mongodb 4.4

### DIFF
--- a/Dockerfile-db
+++ b/Dockerfile-db
@@ -1,3 +1,3 @@
-FROM mongo:4.0
+FROM mongo:4.4
 
 COPY /src/test/resources/db/*.js /docker-entrypoint-initdb.d/

--- a/src/test/java/io/gaia_app/client/controller/AuthenticationRestControllerIT.kt
+++ b/src/test/java/io/gaia_app/client/controller/AuthenticationRestControllerIT.kt
@@ -26,8 +26,8 @@ class AuthenticationRestControllerIT: SharedMongoContainerTest() {
     @BeforeAll
     fun setUp() {
         mongo.emptyDatabase()
-        mongo.runScript("src/test/resources/db/00_team.js")
-        mongo.runScript("src/test/resources/db/10_user.js")
+        mongo.runScript("00_team.js")
+        mongo.runScript("10_user.js")
     }
 
     @Test

--- a/src/test/java/io/gaia_app/credentials/CredentialsRestControllerIT.java
+++ b/src/test/java/io/gaia_app/credentials/CredentialsRestControllerIT.java
@@ -30,9 +30,9 @@ class CredentialsRestControllerIT extends SharedMongoContainerTest {
     @BeforeEach
     void setup() {
         mongo.emptyDatabase();
-        mongo.runScript("src/test/resources/db/00_team.js");
-        mongo.runScript("src/test/resources/db/10_user.js");
-        mongo.runScript("src/test/resources/db/70_credentials.js");
+        mongo.runScript("00_team.js");
+        mongo.runScript("10_user.js");
+        mongo.runScript("70_credentials.js");
     }
 
     @Test

--- a/src/test/java/io/gaia_app/credentials/CredentialsRestControllerVaultIT.java
+++ b/src/test/java/io/gaia_app/credentials/CredentialsRestControllerVaultIT.java
@@ -31,9 +31,9 @@ class CredentialsRestControllerVaultIT extends SharedMongoContainerTest {
     @BeforeEach
     void setup() {
         mongo.emptyDatabase();
-        mongo.runScript("src/test/resources/db/00_team.js");
-        mongo.runScript("src/test/resources/db/10_user.js");
-        mongo.runScript("src/test/resources/db/70_credentials.js");
+        mongo.runScript("00_team.js");
+        mongo.runScript("10_user.js");
+        mongo.runScript("70_credentials.js");
     }
 
     @Test

--- a/src/test/java/io/gaia_app/e2e/SeleniumIT.java
+++ b/src/test/java/io/gaia_app/e2e/SeleniumIT.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Tag("e2e")
-public class SeleniumIT extends SharedMongoContainerTest {
+class SeleniumIT extends SharedMongoContainerTest {
 
     @LocalServerPort
     private int serverPort;
@@ -51,13 +51,13 @@ public class SeleniumIT extends SharedMongoContainerTest {
         driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
 
         mongo.emptyDatabase();
-        mongo.runScript("src/test/resources/db/00_team.js");
-        mongo.runScript("src/test/resources/db/10_user.js");
-        mongo.runScript("src/test/resources/db/20_module.js");
-        mongo.runScript("src/test/resources/db/30_stack.js");
-        mongo.runScript("src/test/resources/db/40_job.js");
-        mongo.runScript("src/test/resources/db/50_step.js");
-        mongo.runScript("src/test/resources/db/60_terraformState.js");
+        mongo.runScript("00_team.js");
+        mongo.runScript("10_user.js");
+        mongo.runScript("20_module.js");
+        mongo.runScript("30_stack.js");
+        mongo.runScript("40_job.js");
+        mongo.runScript("50_step.js");
+        mongo.runScript("60_terraformState.js");
     }
 
     @AfterAll

--- a/src/test/java/io/gaia_app/modules/controller/DockerRegistryRestControllerIT.kt
+++ b/src/test/java/io/gaia_app/modules/controller/DockerRegistryRestControllerIT.kt
@@ -36,7 +36,7 @@ class DockerRegistryRestControllerIT: SharedMongoContainerTest() {
     @BeforeAll
     internal fun setUp() {
         mongo.emptyDatabase()
-        mongo.runScript("src/test/resources/db/10_user.js")
+        mongo.runScript("10_user.js")
     }
 
     @Test

--- a/src/test/java/io/gaia_app/modules/controller/ModuleRestControllerIT.java
+++ b/src/test/java/io/gaia_app/modules/controller/ModuleRestControllerIT.java
@@ -31,9 +31,9 @@ class ModuleRestControllerIT extends SharedMongoContainerTest {
     @BeforeEach
     void setup() {
         mongo.emptyDatabase();
-        mongo.runScript("src/test/resources/db/00_team.js");
-        mongo.runScript("src/test/resources/db/10_user.js");
-        mongo.runScript("src/test/resources/db/20_module.js");
+        mongo.runScript("00_team.js");
+        mongo.runScript("10_user.js");
+        mongo.runScript("20_module.js");
     }
 
     @Test

--- a/src/test/java/io/gaia_app/registries/controller/GithubRegistryControllerIT.kt
+++ b/src/test/java/io/gaia_app/registries/controller/GithubRegistryControllerIT.kt
@@ -52,7 +52,7 @@ class GithubRegistryControllerIT: SharedMongoContainerTest() {
     @BeforeEach
     internal fun setUp() {
         mongo.emptyDatabase()
-        mongo.runScript("src/test/resources/db/10_user.js")
+        mongo.runScript("10_user.js")
     }
 
     @Test

--- a/src/test/java/io/gaia_app/registries/controller/GitlabRegistryControllerIT.kt
+++ b/src/test/java/io/gaia_app/registries/controller/GitlabRegistryControllerIT.kt
@@ -51,7 +51,7 @@ class GitlabRegistryControllerIT: SharedMongoContainerTest() {
     @BeforeEach
     internal fun setUp() {
         mongo.emptyDatabase()
-        mongo.runScript("src/test/resources/db/10_user.js")
+        mongo.runScript("10_user.js")
     }
 
     @Test

--- a/src/test/java/io/gaia_app/stacks/controller/StackRestControllerIT.java
+++ b/src/test/java/io/gaia_app/stacks/controller/StackRestControllerIT.java
@@ -30,10 +30,10 @@ class StackRestControllerIT extends SharedMongoContainerTest {
     @BeforeEach
     void setUp() {
         mongo.emptyDatabase();
-        mongo.runScript("src/test/resources/db/00_team.js");
-        mongo.runScript("src/test/resources/db/10_user.js");
-        mongo.runScript("src/test/resources/db/20_module.js");
-        mongo.runScript("src/test/resources/db/30_stack.js");
+        mongo.runScript("00_team.js");
+        mongo.runScript("10_user.js");
+        mongo.runScript("20_module.js");
+        mongo.runScript("30_stack.js");
     }
 
     @Test

--- a/src/test/java/io/gaia_app/teams/controller/TeamsRestControllerIT.java
+++ b/src/test/java/io/gaia_app/teams/controller/TeamsRestControllerIT.java
@@ -34,8 +34,8 @@ class TeamsRestControllerIT extends SharedMongoContainerTest {
     @BeforeEach
     void setUp() {
         mongo.emptyDatabase();
-        mongo.runScript("src/test/resources/db/00_team.js");
-        mongo.runScript("src/test/resources/db/10_user.js");
+        mongo.runScript("00_team.js");
+        mongo.runScript("10_user.js");
     }
 
     @Test

--- a/src/test/java/io/gaia_app/teams/controller/UsersRestControllerIT.java
+++ b/src/test/java/io/gaia_app/teams/controller/UsersRestControllerIT.java
@@ -46,8 +46,8 @@ class UsersRestControllerIT extends SharedMongoContainerTest {
     @BeforeEach
     void setUp() {
         mongo.emptyDatabase();
-        mongo.runScript("src/test/resources/db/00_team.js");
-        mongo.runScript("src/test/resources/db/10_user.js");
+        mongo.runScript("00_team.js");
+        mongo.runScript("10_user.js");
     }
 
     @Test

--- a/src/test/java/io/gaia_app/test/MongoContainer.java
+++ b/src/test/java/io/gaia_app/test/MongoContainer.java
@@ -23,7 +23,7 @@ public class MongoContainer extends GenericContainer {
     private MongoDatabase database;
 
     public MongoContainer() {
-        super("mongo:4.0");
+        super("mongo:4.4");
         withClasspathResourceMapping("db", GAIA_SCRIPTS_DIRECTORY, BindMode.READ_ONLY);
     }
 

--- a/src/test/java/io/gaia_app/test/MongoContainer.java
+++ b/src/test/java/io/gaia_app/test/MongoContainer.java
@@ -3,15 +3,12 @@ package io.gaia_app.test;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
-import org.apache.commons.io.IOUtils;
-import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.List;
 
 /**
  * A helper class to start a mongodb container
@@ -20,13 +17,14 @@ public class MongoContainer extends GenericContainer {
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoContainer.class);
     private static final int MONGO_PORT = 27017;
+    public static final String GAIA_SCRIPTS_DIRECTORY = "/gaia_scripts/";
 
     private MongoClient client;
     private MongoDatabase database;
 
     public MongoContainer() {
         super("mongo:4.0");
-        setExposedPorts(List.of(MONGO_PORT));
+        withClasspathResourceMapping("db", GAIA_SCRIPTS_DIRECTORY, BindMode.READ_ONLY);
     }
 
     public MongoClient getClient() {
@@ -48,14 +46,13 @@ public class MongoContainer extends GenericContainer {
     }
 
     public void runScript(String resource){
-        try (final FileInputStream fis = new FileInputStream(resource)) {
-            var content = IOUtils.toString(fis, "UTF-8");
-
-            var document = new Document("$eval", content);
-
-            getDatabase().runCommand(document);
-        } catch (IOException e) {
-            LOG.warn("Unable to read file: {} skipped.", resource);
+        try {
+            var result = this.execInContainer("mongo", GAIA_SCRIPTS_DIRECTORY+resource);
+            if(result.getExitCode() != 0){
+                LOG.error("Script execution raised an error : {}", result.getStdout());
+            }
+        } catch (IOException | InterruptedException e) {
+            LOG.warn("Unable to execute script: {} skipped.", resource);
         }
     }
 


### PR DESCRIPTION
This PR brings support to mongodb 4.4, by removing calls to `db.eval()` and using mongo shell to execute data scripts.

resolves #418 