### PR TITLE
✅ : stabilize users page tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
             <plugin>
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>
-                <version>1.5.2</version>
+                <version>1.6.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.pitest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
         <kotlin.version>1.4.10</kotlin.version>
         <kotlinx.version>1.3.9</kotlinx.version>
-        <testcontainers.version>1.14.3</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <node.version>v12.16.0</node.version>
         <npm.version>6.13.4</npm.version>
         <spring.vault.version>2.2.2.RELEASE</spring.vault.version>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.5</version>
+                    <version>0.8.6</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/main/client/app/pages/users/users.vue
+++ b/src/main/client/app/pages/users/users.vue
@@ -13,6 +13,7 @@
 
     <div class="block mt-3">
       <b-table
+        id="usersTable"
         :items="users"
         :fields="fields"
         striped

--- a/src/test/features/io/gaia_app/e2e/basic_navigation.feature
+++ b/src/test/features/io/gaia_app/e2e/basic_navigation.feature
@@ -28,4 +28,5 @@ Feature: Basic Navigation
 
     Scenario: View users list
         When I go on the users page
+        Then I can see 5 users
         Then Percy takes a snapshot named 'Users'

--- a/src/test/java/io/gaia_app/e2e/pages/UsersPage.kt
+++ b/src/test/java/io/gaia_app/e2e/pages/UsersPage.kt
@@ -1,0 +1,29 @@
+package io.gaia_app.e2e.pages
+
+import org.openqa.selenium.By
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.WebElement
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.openqa.selenium.support.ui.ExpectedConditions.titleIs
+import org.openqa.selenium.support.ui.WebDriverWait
+
+class UsersPage(private val webDriver: WebDriver) {
+
+    private lateinit var usersRows: List<WebElement>
+
+    init {
+        val wait = WebDriverWait(webDriver, 10)
+        wait.until(titleIs("Gaia - Users"))
+    }
+
+    fun usersCount() = usersRows.size
+
+    fun waitForPageLoaded() {
+        val wait = WebDriverWait(webDriver, 10)
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("usersTable")))
+
+        val usersTable = webDriver.findElement(By.id("usersTable"))
+        usersRows = usersTable.findElement(By.tagName("tbody")).findElements(By.tagName("tr"))
+    }
+
+}

--- a/src/test/java/io/gaia_app/e2e/stepDefs/UsersStepDefs.java
+++ b/src/test/java/io/gaia_app/e2e/stepDefs/UsersStepDefs.java
@@ -1,7 +1,8 @@
 package io.gaia_app.e2e.stepDefs;
 
+import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import io.gaia_app.e2e.pages.JobPage;
+import io.gaia_app.e2e.pages.UsersPage;
 import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.pagefactory.AjaxElementLocatorFactory;
 
@@ -9,8 +10,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class UsersStepDefs extends StepDefs {
 
+    UsersPage page;
+
     @When("I go on the users page")
     public void iGoOnTheUsersPage() {
         driver.get(baseUrl()+"/users");
+
+        page = new UsersPage(driver);
+        PageFactory.initElements(new AjaxElementLocatorFactory(driver, 10), page);
+        page.waitForPageLoaded();
+    }
+
+    @Then("I can see {int} users")
+    public void iCanSeeUsers(int expectedUsersCount) {
+        assertThat(page.usersCount()).isEqualTo(expectedUsersCount);
     }
 }


### PR DESCRIPTION
Wait for the table to be loaded before taking a percy snapshot.

Also updates all test-related dependencies.

This will resolve #506, #500, #433