### PR TITLE
🔥 : remove pitest dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,25 +324,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.pitest</groupId>
-                <artifactId>pitest-maven</artifactId>
-                <version>1.6.1</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.pitest</groupId>
-                        <artifactId>pitest-junit5-plugin</artifactId>
-                        <version>0.12</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <excludedTestClasses>*IT</excludedTestClasses>
-                    <avoidCallsTo>
-                        <avoidCallsTo>kotlin.jvm.internal</avoidCallsTo>
-                    </avoidCallsTo>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>${frontend-maven-plugin.version}</version>


### PR DESCRIPTION
we do not use this plugin as part of our testing process, so removing it