### PR TITLE
➖ : remove bootstrap direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@fortawesome/vue-fontawesome": "^2.0.0",
     "ansi-to-html": "^0.6.14",
     "axios": "^0.21.1",
-    "bootstrap": "^4.5.2",
     "bootstrap-vue": "^2.17.3",
     "core-js": "^3.6.5",
     "corejs-typeahead": "^1.3.1",


### PR DESCRIPTION
as we rely on bootstrap-vue, which has bootstrap dependency, it seems not necessary
to keep the direct dependency to bootstrap

it also may save us from version de-sync