### PR TITLE
🐛 : add export for java.naming/com.sun.jndi.ldap package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ EXPOSE 8080
 COPY --from=BUILD /usr/src/app/target/*.jar /opt/target/gaia.jar
 WORKDIR /opt/target
 
+ENV JDK_JAVA_OPTIONS "--add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
+
 CMD ["java", "-jar", "gaia.jar"]


### PR DESCRIPTION
Add an option to export the java.naming/com.sun.jndi.ldap package.
This package is used by spring-ldap.
Since jdk-16, internal modules are strongly encapsulated:
see https://openjdk.java.net/jeps/396

The option is passed using the JDK_JAVA_OPTIONS env var
see https://docs.oracle.com/en/java/javase/16/docs/specs/man/java.html#using-the-jdk_java_options-launcher-environment-variable

resolves #596