### PR TITLE
🐛 : prevent spring from loading LdapAutoConfiguration

### DIFF
--- a/src/main/java/io/gaia_app/config/security/ldap/CustomLdapAutoConfiguration.java
+++ b/src/main/java/io/gaia_app/config/security/ldap/CustomLdapAutoConfiguration.java
@@ -1,0 +1,13 @@
+package io.gaia_app.config.security.ldap;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableAutoConfiguration(exclude = LdapAutoConfiguration.class)
+@ConditionalOnProperty(prefix = "gaia", name = "ldap.enabled", havingValue = "false", matchIfMissing = true)
+public class CustomLdapAutoConfiguration {
+    // this blocks the load of ldap auto configuration if the ldap is not enabled
+}

--- a/src/test/java/io/gaia_app/config/security/ldap/LdapSecurityConfigIT.java
+++ b/src/test/java/io/gaia_app/config/security/ldap/LdapSecurityConfigIT.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.ldap.core.LdapTemplate;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -21,6 +22,12 @@ class LdapSecurityConfigIT {
                 @Autowired(required = false) LdapSecurityConfig ldapSecurityConfig) {
             assertNull(ldapSecurityConfig);
         }
+
+        @Test
+        void ldapTemplate_shouldNotBeInstantiated(
+            @Autowired(required = false) LdapTemplate ldapTemplate) {
+            assertNull(ldapTemplate);
+        }
     }
 
     @Nested
@@ -34,6 +41,12 @@ class LdapSecurityConfigIT {
         void ldapSecurityConfig_shouldBeInstantiated(
                 @Autowired(required = false) LdapSecurityConfig ldapSecurityConfig) {
             assertNotNull(ldapSecurityConfig);
+        }
+
+        @Test
+        void ldapTemplate_shouldBeInstantiated(
+            @Autowired(required = false) LdapTemplate ldapTemplate) {
+            assertNotNull(ldapTemplate);
         }
     }
 }


### PR DESCRIPTION
when gaia.ldap.enabled = false, LdapAutoConfiguration should not be loaded, and no Ldap-related bean should be instanciated.