### PR TITLE
🐛 : up to date plans should not ask to apply

### DIFF
--- a/src/main/client/app/pages/stacks/job/job-step.vue
+++ b/src/main/client/app/pages/stacks/job/job-step.vue
@@ -52,7 +52,7 @@
           Resource changes :
           <b>{{ step.plan.createCount }}</b> to add,
           <b>{{ step.plan.updateCount }}</b> to change,
-          <b>{{ step.plan.delete }}</b> to delete
+          <b>{{ step.plan.deleteCount }}</b> to delete
         </p>
       </div>
     </div>

--- a/src/main/client/app/pages/stacks/job/job.vue
+++ b/src/main/client/app/pages/stacks/job/job.vue
@@ -80,8 +80,12 @@
       secondStepTitle() {
         return this.job.type === 'RUN' ? 'apply' : 'destroy';
       },
+      isPlanUpToDate() {
+        return this.job.steps[0] && this.job.steps[0].plan && this.job.steps[0].plan.upToDate;
+      },
       isSecondStepDoable() {
         return this.job.status
+          && !this.isPlanUpToDate
           && !this.job.status.includes('PENDING')
           && !this.job.status.includes('STARTED')
           && !this.job.status.includes('FAILED')

--- a/src/main/java/io/gaia_app/runner/RunnerCommandBuilder.java
+++ b/src/main/java/io/gaia_app/runner/RunnerCommandBuilder.java
@@ -105,7 +105,7 @@ public class RunnerCommandBuilder {
      * @return
      */
     String buildPlanDestroyScript(Job job, Stack stack, TerraformModule module) {
-        return buildScript(job, stack, module, "terraform plan -destroy -detailed-exitcode", false);
+        return buildScript(job, stack, module, "terraform plan -out plan.binary -destroy -detailed-exitcode", true);
     }
 
     /**

--- a/src/main/java/io/gaia_app/stacks/bo/Plan.kt
+++ b/src/main/java/io/gaia_app/stacks/bo/Plan.kt
@@ -19,6 +19,8 @@ data class Plan(val id:String = UUID.randomUUID().toString(),
     fun getDeleteCount() = resource_changes.count { it.change.actions.contains(ChangesTypes.DELETE) }
     fun getNoOpCount() = resource_changes.count { it.change.actions.contains(ChangesTypes.NOOP) }
 
+    fun isUpToDate() = getCreateCount() == 0 && getUpdateCount() == 0 && getDeleteCount() == 0
+
 }
 
 /**

--- a/src/test/java/io/gaia_app/runner/RunnerCommandBuilderTest.java
+++ b/src/test/java/io/gaia_app/runner/RunnerCommandBuilderTest.java
@@ -184,7 +184,8 @@ class RunnerCommandBuilderTest {
         assertTrue(script.contains("echo '[gaia] generating backend configuration'"));
         assertTrue(script.contains("terraform version"));
         assertTrue(script.contains("terraform init"));
-        assertTrue(script.contains("terraform plan -destroy"));
+        assertTrue(script.contains("terraform plan -out plan.binary -destroy"));
+        assertTrue(script.contains("terraform show -json plan.binary > plan.json"));
     }
 
     @Test
@@ -204,7 +205,8 @@ class RunnerCommandBuilderTest {
         assertTrue(script.contains("echo '[gaia] generating backend configuration'"));
         assertTrue(script.contains("terraform version"));
         assertTrue(script.contains("terraform init"));
-        assertTrue(script.contains("terraform plan -destroy"));
+        assertTrue(script.contains("terraform plan -out plan.binary -destroy"));
+        assertTrue(script.contains("terraform show -json plan.binary > plan.json"));
     }
 
     @Test
@@ -226,7 +228,8 @@ class RunnerCommandBuilderTest {
         assertTrue(script.contains("echo '[gaia] generating backend configuration'"));
         assertTrue(script.contains("terraform version"));
         assertTrue(script.contains("terraform init"));
-        assertTrue(script.contains("terraform plan -destroy"));
+        assertTrue(script.contains("terraform plan -out plan.binary -destroy"));
+        assertTrue(script.contains("terraform show -json plan.binary > plan.json"));
     }
 
 

--- a/src/test/java/io/gaia_app/stacks/bo/PlanTest.kt
+++ b/src/test/java/io/gaia_app/stacks/bo/PlanTest.kt
@@ -24,4 +24,28 @@ internal class PlanTest {
         assertThat(plan.resource_changes).containsAll(listOf(container, image))
     }
 
+    @Test
+    fun `a plan with no changes should be 'up to date'`() {
+        val plan = Plan(terraform_version = "0", resource_changes = listOf())
+        assertThat(plan.isUpToDate()).isTrue
+    }
+
+    @Test
+    fun `a plan with only no-op changes should be 'up to date'`() {
+        val noOpChange = ResourceChange("address", "provider", "type", Change(listOf(ChangesTypes.NOOP)))
+        val plan = Plan(terraform_version = "0", resource_changes = listOf(noOpChange))
+        assertThat(plan.isUpToDate()).isTrue
+    }
+
+    @Test
+    fun `a plan with at least one create,update, or delete should not be 'up to date'`() {
+        val createChange = ResourceChange("address", "provider", "type", Change(listOf(ChangesTypes.CREATE)))
+        val updateChange = ResourceChange("address", "provider", "type", Change(listOf(ChangesTypes.UPDATE)))
+        val deleteChange = ResourceChange("address", "provider", "type", Change(listOf(ChangesTypes.DELETE)))
+
+        assertThat(Plan(terraform_version = "0", resource_changes = listOf(createChange)).isUpToDate()).isFalse
+        assertThat(Plan(terraform_version = "0", resource_changes = listOf(updateChange)).isUpToDate()).isFalse
+        assertThat(Plan(terraform_version = "0", resource_changes = listOf(deleteChange)).isUpToDate()).isFalse
+    }
+
 }


### PR DESCRIPTION
Simply compute the plan to check if it is up-to-date or not, and use this property to show/mask the "apply" button.

This resolves #139 

## Screenshots :
### up to date plan :
![image](https://user-images.githubusercontent.com/7531844/116429408-2660fe80-a846-11eb-9a90-bcdfe9b9be83.png)

### plan needing an apply :
![image](https://user-images.githubusercontent.com/7531844/116429492-3b3d9200-a846-11eb-88cf-b1992280b890.png)
 