### PR TITLE
🐛 : correct Settings env vars propagation to runner

### DIFF
--- a/src/main/java/io/gaia_app/runner/RunnerController.java
+++ b/src/main/java/io/gaia_app/runner/RunnerController.java
@@ -1,6 +1,7 @@
 package io.gaia_app.runner;
 
 import io.gaia_app.credentials.CredentialsService;
+import io.gaia_app.settings.bo.Settings;
 import io.gaia_app.stacks.bo.*;
 import io.gaia_app.stacks.repository.JobRepository;
 import io.gaia_app.stacks.repository.PlanRepository;
@@ -12,7 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -43,6 +44,9 @@ public class RunnerController {
 
     @Autowired
     private PlanRepository planRepository;
+
+    @Autowired
+    private Settings settings;
 
     @GetMapping(value = "/stacks/{id}.tfvars", produces = "text/plain")
     public String tfvars(@PathVariable String id){
@@ -80,11 +84,13 @@ public class RunnerController {
             }
         }
 
-        List<String> env = Collections.emptyList();
+        List<String> env = new ArrayList<>();
+        env.addAll(settings.env());
+
         if(stack.getCredentialsId() != null){
             var credentials = this.credentialsService.load(stack.getCredentialsId()).orElse(null);
             if(credentials != null){
-                env = credentials.toEnv();
+                env.addAll(credentials.toEnv());
             }
         }
 

--- a/src/test/java/io/gaia_app/runner/RunnerControllerTest.java
+++ b/src/test/java/io/gaia_app/runner/RunnerControllerTest.java
@@ -3,6 +3,7 @@ package io.gaia_app.runner;
 import io.gaia_app.credentials.Credentials;
 import io.gaia_app.credentials.CredentialsService;
 import io.gaia_app.modules.bo.TerraformImage;
+import io.gaia_app.settings.bo.Settings;
 import io.gaia_app.stacks.bo.*;
 import io.gaia_app.stacks.repository.JobRepository;
 import io.gaia_app.stacks.repository.StackRepository;
@@ -40,6 +41,9 @@ class RunnerControllerTest {
 
     @Mock
     private CredentialsService credentialsService;
+
+    @Mock
+    private Settings settings;
 
     private Step step;
 
@@ -162,7 +166,7 @@ class RunnerControllerTest {
     }
 
     @Test
-    void findFirstRunnableStep_shouldStackCredentials() {
+    void findFirstRunnableStep_shouldImportStackCredentials() {
         //given
         stack.setCredentialsId("fakeCredentials");
 
@@ -177,4 +181,18 @@ class RunnerControllerTest {
         assertThat(result)
             .containsEntry("env", credentials.toEnv());
     }
+
+    @Test
+    void findFirstRunnableStep_shouldImportSettingsEnvVars() {
+        //given
+        when(settings.env()).thenReturn(List.of("LED=ZEPPELIN", "THE=DOORS"));
+
+        // when
+        var result = runnerController.findFirstRunnableStep();
+
+        // then
+        assertThat(result)
+            .containsEntry("env", List.of("LED=ZEPPELIN", "THE=DOORS"));
+    }
+
 }


### PR DESCRIPTION
## Description

Adds the missing propagation of the Settings env vars to the Jobs, when the runner gets them.

## Checklist for the pull request author

- [x] Tests added for this feature
- [x] Commit messages follow conventions (see [CONTRIBUTING.md](CONTRIBUTING.md))
- [x] Commits are combined ( 1 commit / type and scope )
- [x] Documentation created / updated (if necessary)
- [x] No new sonarqube issues added
- [x] CI pipeline is OK
- [x] Pull request is fast-forward to the `main` branch
- [ ] The last commit of this merge request :
    - [ ] updates the `pom.xml` to a new minor or major version
    - [ ] updates the `CHANGELOG.md`

## Checklist for the project maintainer

- [x] Review the code, and add a *Review Approval* if everything is ok
- [x] This pull request will be merged in merge-commit mode
    - (in github or with the CLI, see [CONTRIBUTING.md](CONTRIBUTING.md))

### After the merge

- [ ] Put the tag on the merged commit
    - (in github or with the CLI, see [CONTRIBUTING.md](CONTRIBUTING.md))
- [ ] Follow the pipeline for the tag, which should build & release the package (maven or docker)

## Issues / Links

* issue #667 

