### PR TITLE
Feature/module refresh for manually imported modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
           # fetching all history (to help sonar computing PRs)
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - name: Run Maven tests
-        run: mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar -DexcludedGroups=e2e -P ci-tu
+        run: mvn --batch-mode org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar -DexcludedGroups=e2e -P ci-tu
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/visual-non-regression-tests.yml
+++ b/.github/workflows/visual-non-regression-tests.yml
@@ -19,7 +19,7 @@ jobs:
           # fetching all history (to help sonar computing PRs)
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/visual-non-regression-tests.yml
+++ b/.github/workflows/visual-non-regression-tests.yml
@@ -26,6 +26,6 @@ jobs:
       - name: Percy Test
         uses: percy/exec-action@v0.3.1
         with:
-          command: "mvn test -Dgroups=e2e"
+          command: "mvn --batch-mode test -Dgroups=e2e"
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+<a name="2.3.0"></a>
+## 2.3.0 (2022-05-08)
+
+### Added
+
+- ✨ : update registry details when module is saved [[e15dbcd](https://github.com/gaia-app/gaia/commit/e15dbcd37af99caf5ec64a08f136d0f14aec1474)]
+- ✨ : compute registry details for Gitlab urls [[8436476](https://github.com/gaia-app/gaia/commit/8436476813599b12e8f42c679e8872704e7493ba)]
+    * ✨ : compute registry details for Github ssh urls ([c0c3153](https://github.com/gaia-app/gaia/commit/c0c3153940fbcb795d434e45595d2eb9822b7be8))
+    * ✨ : compute registry details for Github https urls ([1bfcecc](https://github.com/gaia-app/gaia/commit/1bfceccb1e0fe928e141362c90ef0e6237cf7c2b))
+
+### Changed
+
+- ⬆️ : bump kotlin to 1.6.21 [[d569337](https://github.com/gaia-app/gaia/commit/d5693373fba3a01cfa0a0770333003d491ad1918)]
+- ⬆️ : bump jacoco-maven-plugin to 0.8.8 [[4573ad1](https://github.com/gaia-app/gaia/commit/4573ad1e6a69c12801b28c091bce2028dc37c8ea)]
+- ⬆️ : bump setup-java action to v3 [[8347df6](https://github.com/gaia-app/gaia/commit/8347df637648b4d18bed9ab6135a6d08b6cb7ec8)]
+- ⬆️ : bump kotlin.version to 1.6.0 [[0004c28](https://github.com/gaia-app/gaia/commit/0004c28b0480910b3131b59aa99b386c5057e594)]
+- 🔧 : add com.sun.jndi.ldap module export [[808b16d](https://github.com/gaia-app/gaia/commit/808b16d7a795d0bbb6a3375b21071be6ee5667d7)]
+- ⬆️ : upgrade to java 17 [[a091b2a](https://github.com/gaia-app/gaia/commit/a091b2a96287b49e6be16cf782884ce7836cc631)]
+    *  👷 : migrate to java 17 ([c0d4fed](https://github.com/gaia-app/gaia/commit/c0d4fed44a9d1caa6353d0634f15629394694cbd))
+    * ⬆️ : upgrade to java 17 ([619bf1e](https://github.com/gaia-app/gaia/commit/619bf1e92922be21782911a75dec39ea3f17b5f8))
+- 🔧 : update default mongodb URL to use 27017 port [[46a3376](https://github.com/gaia-app/gaia/commit/46a33765f1f50bff160b333ac67437dd3066b0db)]
+- ♻️ : remove redundant semicolons [[da4c98e](https://github.com/gaia-app/gaia/commit/da4c98e2e90a44d8084117566ed5ad11add8a51e)]
+- ♻️ : remove redundant qualifiers [[be3273b](https://github.com/gaia-app/gaia/commit/be3273bf6f40b83e352005b33e314832f5e40139)]
+    * 🔥 : remove redundent modifiers ([8649046](https://github.com/gaia-app/gaia/commit/86490460f744eee521a05eacd071bfd9db523169))
+- ♻️ : remove unnecessary non-null assertion [[0aeb6eb](https://github.com/gaia-app/gaia/commit/0aeb6eb896944f0aa8007ba0b49b295c7456bd24)]
+- ♻️ : replace field injection with constructor [[56de233](https://github.com/gaia-app/gaia/commit/56de2339f208ee4e8b3f44b9dca57646afc8d497)]
+- ♻️ : replace null checks with ifPresent() [[446cdd9](https://github.com/gaia-app/gaia/commit/446cdd978d81a560580e8c5cd92babfa766b11e3)]
+- ♻️ : replace addAll with parametrized constructor call [[7352877](https://github.com/gaia-app/gaia/commit/73528770688d6b537aa20f59c010f3349d8ad7a7)]
+- ♻️ : replace unchecked assignment [[a5ff22b](https://github.com/gaia-app/gaia/commit/a5ff22b53eaf76790141098dc92a9ef0134006d7)]
+- 🎨 : remove unnecessary semicolon [[7ae64ea](https://github.com/gaia-app/gaia/commit/7ae64ea7fdfd79a7298038905bf2f9a7cd76e6e5)]
+- ♻️ : stop using deprecated constructor [[65e4b36](https://github.com/gaia-app/gaia/commit/65e4b36d4b3068f10cade84d15ecb83dd47f9a05)]
+- ♻️ : use redirectUri instead of redirectUriTemplate [[492778b](https://github.com/gaia-app/gaia/commit/492778be3ea9cd383bb9a05d237d64a2e033d3a1)]
+- 🚚 : split configuration of oauth providers [[bcee58c](https://github.com/gaia-app/gaia/commit/bcee58c44a81d1eacdcdda2f632d02d9dadc0ddc)]
+
+### Removed
+
+- 🔥 : remove unused imports [[7ffa067](https://github.com/gaia-app/gaia/commit/7ffa067560be69f00877f46efc2281b4523bd538)]
+- 🔥 : remove redundant throws clause [[164fdcd](https://github.com/gaia-app/gaia/commit/164fdcde3e49bad4864bac5c85e4cde010b661a7)]
+- 🔥 : remove unnecessary imports [[a230bdd](https://github.com/gaia-app/gaia/commit/a230bdd48438d4a72320c241102deeb9c65f423b)]
+- 🔥 : remove unused dockerDaemon settings [[929914c](https://github.com/gaia-app/gaia/commit/929914cf8c084d705e8e8c56922283d2dd6bf19e)]
+
+### Fixed
+
+- 🐛 : group parts of the regex together to make the intended operator precedence explicit [[b1aeaca](https://github.com/gaia-app/gaia/commit/b1aeaca6edfbfc86fa90ceda614437e59143c410)]
+
+### Security
+
+- 🔒 : auto create admin user on startup [[f4ba7e9](https://github.com/gaia-app/gaia/commit/f4ba7e9ad4a2ec9ec36fdda206161d681b8653a4)]
+
+### Miscellaneous
+
+-  👷 : set maven to batch-mode [[4d5b722](https://github.com/gaia-app/gaia/commit/4d5b7227a98e7f2173cb49227be08230f0a44dce)]
+- 🙈 : add node_modules to .dockerignore [[262ce92](https://github.com/gaia-app/gaia/commit/262ce92962ccd1d1fa2706af3f82a729541437fe)]
+- 📝 : add documentation links [[6dcb23a](https://github.com/gaia-app/gaia/commit/6dcb23a998eb2e449002757ffe2fcc942702f012)]
+
+
 <a name="2.2.0"></a>
 ## 2.2.0 (2021-08-20)
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <npm.version>6.13.4</npm.version>
         <spring.vault.version>2.2.2.RELEASE</spring.vault.version>
         <frontend-maven-plugin.version>1.11.0</frontend-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
 
         <sonar.projectKey>gaia-app:gaia</sonar.projectKey>
         <sonar.organization>gaia-app</sonar.organization>
@@ -236,7 +237,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.7</version>
+                    <version>${jacoco-maven-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.gaia_app</groupId>
     <artifactId>gaia</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.3.0</version>
     <packaging>jar</packaging>
 
     <name>gaia</name>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <cucumber-jvm.version>6.10.0</cucumber-jvm.version>
         <jersey.version>2.27</jersey.version>
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
-        <kotlin.version>1.6.0</kotlin.version>
+        <kotlin.version>1.6.21</kotlin.version>
         <kotlinx.version>1.5.1</kotlinx.version>
         <testcontainers.version>1.15.2</testcontainers.version>
         <node.version>v12.16.0</node.version>

--- a/src/main/java/io/gaia_app/credentials/Credentials.kt
+++ b/src/main/java/io/gaia_app/credentials/Credentials.kt
@@ -1,17 +1,14 @@
 package io.gaia_app.credentials
 
+
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import org.springframework.data.annotation.Id
-
-
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
-import com.fasterxml.jackson.annotation.JsonView
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import io.gaia_app.teams.User
 import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.DBRef
 import org.springframework.data.mongodb.core.mapping.Document
 

--- a/src/main/java/io/gaia_app/modules/ModuleService.java
+++ b/src/main/java/io/gaia_app/modules/ModuleService.java
@@ -1,0 +1,14 @@
+package io.gaia_app.modules;
+
+import io.gaia_app.modules.bo.TerraformModule;
+
+public interface ModuleService {
+
+    /**
+     * Updates the registry details for a module.
+     * It tries to compute a project id from an URL, and updates the module.
+     * @param module module to update
+     */
+    void updateRegistryDetails(TerraformModule module);
+
+}

--- a/src/main/java/io/gaia_app/modules/ModuleServiceImpl.java
+++ b/src/main/java/io/gaia_app/modules/ModuleServiceImpl.java
@@ -5,7 +5,9 @@ import io.gaia_app.registries.RegistryDetails;
 import io.gaia_app.registries.RegistryType;
 import org.springframework.stereotype.Service;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 @Service
 public class ModuleServiceImpl implements ModuleService {
@@ -15,16 +17,25 @@ public class ModuleServiceImpl implements ModuleService {
      * The first group (.+?) expands as few times as possible.
      * The second non-capturing group (?:) matches the end of the line or .git
      */
-    private static final String GITHUB_HTTPS_REPOSITORY_URL_REGEX = "https://github\\.com/(.+?)(?:$|\\.git$)";
+    private static final Pattern GITHUB_HTTPS_REPOSITORY_URL_REGEX = Pattern.compile("https://github\\.com/(.+?)(?:$|\\.git$)");
+
+    /**
+     * matches git@github.com:something(.git), and captures 'something'.
+     * The first group (.+?) expands as few times as possible.
+     * The second non-capturing group (?:) matches the end of the line or .git
+     */
+    private static final Pattern GITHUB_SSH_REPOSITORY_URL_REGEX = Pattern.compile("git@github\\.com:(.+?)(?:$|\\.git$)");
 
     @Override
     public void updateRegistryDetails(TerraformModule module) {
-        var pattern = Pattern.compile(GITHUB_HTTPS_REPOSITORY_URL_REGEX);
-        var matcher = pattern.matcher(module.getGitRepositoryUrl());
-
-        if (matcher.matches()) {
-            var projectId = matcher.group(1);
-            module.setRegistryDetails(new RegistryDetails(RegistryType.GITHUB, projectId));
-        }
+        // find first pattern that matches, then computes the details
+        Stream.of(GITHUB_HTTPS_REPOSITORY_URL_REGEX, GITHUB_SSH_REPOSITORY_URL_REGEX)
+            .map(pattern -> pattern.matcher(module.getGitRepositoryUrl()))
+            .filter(Matcher::matches)
+            .findFirst()
+            .ifPresent(it -> {
+                var projectId = it.group(1);
+                module.setRegistryDetails(new RegistryDetails(RegistryType.GITHUB, projectId));
+            });
     }
 }

--- a/src/main/java/io/gaia_app/modules/ModuleServiceImpl.java
+++ b/src/main/java/io/gaia_app/modules/ModuleServiceImpl.java
@@ -1,0 +1,30 @@
+package io.gaia_app.modules;
+
+import io.gaia_app.modules.bo.TerraformModule;
+import io.gaia_app.registries.RegistryDetails;
+import io.gaia_app.registries.RegistryType;
+import org.springframework.stereotype.Service;
+
+import java.util.regex.Pattern;
+
+@Service
+public class ModuleServiceImpl implements ModuleService {
+
+    /**
+     * matches https://github.com/something(.git), and captures 'something'.
+     * The first group (.+?) expands as few times as possible.
+     * The second non-capturing group (?:) matches the end of the line or .git
+     */
+    private static final String GITHUB_HTTPS_REPOSITORY_URL_REGEX = "https://github\\.com/(.+?)(?:$|\\.git$)";
+
+    @Override
+    public void updateRegistryDetails(TerraformModule module) {
+        var pattern = Pattern.compile(GITHUB_HTTPS_REPOSITORY_URL_REGEX);
+        var matcher = pattern.matcher(module.getGitRepositoryUrl());
+
+        if (matcher.matches()) {
+            var projectId = matcher.group(1);
+            module.setRegistryDetails(new RegistryDetails(RegistryType.GITHUB, projectId));
+        }
+    }
+}

--- a/src/main/java/io/gaia_app/modules/ModuleServiceImpl.java
+++ b/src/main/java/io/gaia_app/modules/ModuleServiceImpl.java
@@ -20,30 +20,30 @@ public class ModuleServiceImpl implements ModuleService {
     /**
      * matches https://github.com/something(.git), and captures 'something'.
      * The first group (.+?) expands as few times as possible.
-     * The second non-capturing group (?:) matches the end of the line or .git
+     * The second non-capturing group (?:) matches the end of the line ($) or .git$
      */
-    private static final Pattern GITHUB_HTTPS_REPOSITORY_URL_REGEX = Pattern.compile("https://github\\.com/(.+?)(?:$|\\.git$)");
+    private static final Pattern GITHUB_HTTPS_REPOSITORY_URL_REGEX = Pattern.compile("https://github\\.com/(.+?)(?:(?:$)|(?:\\.git$))");
 
     /**
      * matches git@github.com:something(.git), and captures 'something'.
      * The first group (.+?) expands as few times as possible.
      * The second non-capturing group (?:) matches the end of the line or .git
      */
-    private static final Pattern GITHUB_SSH_REPOSITORY_URL_REGEX = Pattern.compile("git@github\\.com:(.+?)(?:$|\\.git$)");
+    private static final Pattern GITHUB_SSH_REPOSITORY_URL_REGEX = Pattern.compile("git@github\\.com:(.+?)(?:(?:$)|(?:\\.git$))");
 
     /**
      * matches https://gitlab.com/something(.git), and captures 'something'.
      * The first group (.+?) expands as few times as possible.
      * The second non-capturing group (?:) matches the end of the line or .git
      */
-    private static final Pattern GITLAB_HTTPS_REPOSITORY_URL_REGEX = Pattern.compile("https://gitlab\\.com/(.+?)(?:/?$|\\.git$)");
+    private static final Pattern GITLAB_HTTPS_REPOSITORY_URL_REGEX = Pattern.compile("https://gitlab\\.com/(.+?)(?:(?:/?$)|(?:\\.git$))");
 
     /**
      * matches git@gitlab.com:something(.git), and captures 'something'.
      * The first group (.+?) expands as few times as possible.
      * The second non-capturing group (?:) matches the end of the line or .git
      */
-    private static final Pattern GITLAB_SSH_REPOSITORY_URL_REGEX = Pattern.compile("git@gitlab\\.com:(.+?)(?:$|\\.git$)");
+    private static final Pattern GITLAB_SSH_REPOSITORY_URL_REGEX = Pattern.compile("git@gitlab\\.com:(.+?)(?:(?:$)|(?:\\.git$))");
 
     private Map<RegistryType, RegistryApi<? extends SourceRepository>> registryApis;
 

--- a/src/main/java/io/gaia_app/modules/ModuleServiceImpl.java
+++ b/src/main/java/io/gaia_app/modules/ModuleServiceImpl.java
@@ -1,10 +1,15 @@
 package io.gaia_app.modules;
 
 import io.gaia_app.modules.bo.TerraformModule;
+import io.gaia_app.registries.RegistryApi;
 import io.gaia_app.registries.RegistryDetails;
 import io.gaia_app.registries.RegistryType;
+import io.gaia_app.registries.SourceRepository;
+import io.gaia_app.registries.github.GithubRegistryApi;
+import io.gaia_app.registries.gitlab.GitlabRegistryApi;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -26,16 +31,51 @@ public class ModuleServiceImpl implements ModuleService {
      */
     private static final Pattern GITHUB_SSH_REPOSITORY_URL_REGEX = Pattern.compile("git@github\\.com:(.+?)(?:$|\\.git$)");
 
+    /**
+     * matches https://gitlab.com/something(.git), and captures 'something'.
+     * The first group (.+?) expands as few times as possible.
+     * The second non-capturing group (?:) matches the end of the line or .git
+     */
+    private static final Pattern GITLAB_HTTPS_REPOSITORY_URL_REGEX = Pattern.compile("https://gitlab\\.com/(.+?)(?:/?$|\\.git$)");
+
+    /**
+     * matches git@gitlab.com:something(.git), and captures 'something'.
+     * The first group (.+?) expands as few times as possible.
+     * The second non-capturing group (?:) matches the end of the line or .git
+     */
+    private static final Pattern GITLAB_SSH_REPOSITORY_URL_REGEX = Pattern.compile("git@gitlab\\.com:(.+?)(?:$|\\.git$)");
+
+    private Map<RegistryType, RegistryApi<? extends SourceRepository>> registryApis;
+
+    public ModuleServiceImpl(GithubRegistryApi githubRegistryApi, GitlabRegistryApi gitlabRegistryApiMap) {
+        this.registryApis = Map.of(RegistryType.GITHUB, githubRegistryApi, RegistryType.GITLAB, gitlabRegistryApiMap);
+    }
+
     @Override
     public void updateRegistryDetails(TerraformModule module) {
+        RegistryType registryType;
+        if (module.getGitRepositoryUrl().contains("github")) {
+            registryType = RegistryType.GITHUB;
+        } else if (module.getGitRepositoryUrl().contains("gitlab")) {
+            registryType = RegistryType.GITLAB;
+        } else {
+            // could not match any registry type from the URL
+            return;
+        }
         // find first pattern that matches, then computes the details
-        Stream.of(GITHUB_HTTPS_REPOSITORY_URL_REGEX, GITHUB_SSH_REPOSITORY_URL_REGEX)
+        Stream.of(
+                GITHUB_HTTPS_REPOSITORY_URL_REGEX,
+                GITHUB_SSH_REPOSITORY_URL_REGEX,
+                GITLAB_HTTPS_REPOSITORY_URL_REGEX,
+                GITLAB_SSH_REPOSITORY_URL_REGEX)
             .map(pattern -> pattern.matcher(module.getGitRepositoryUrl()))
             .filter(Matcher::matches)
             .findFirst()
             .ifPresent(it -> {
-                var projectId = it.group(1);
-                module.setRegistryDetails(new RegistryDetails(RegistryType.GITHUB, projectId));
+                var projectName = it.group(1);
+                // get project id from project name
+                var repository = registryApis.get(registryType).getRepository(projectName);
+                module.setRegistryDetails(new RegistryDetails(registryType, repository.getId()));
             });
     }
 }

--- a/src/main/java/io/gaia_app/modules/controller/ModuleRestController.java
+++ b/src/main/java/io/gaia_app/modules/controller/ModuleRestController.java
@@ -77,6 +77,9 @@ public class ModuleRestController {
             throw new ModuleForbiddenException();
         }
 
+        // try to update registry details
+        moduleService.updateRegistryDetails(module);
+
         module.getModuleMetadata().setUpdatedBy(user);
         module.getModuleMetadata().setUpdatedAt(LocalDateTime.now());
 
@@ -101,12 +104,6 @@ public class ModuleRestController {
         var existingModule = moduleRepository.findById(id).orElseThrow(ModuleNotFoundException::new);
         if (!existingModule.isAuthorizedFor(user)) {
             throw new ModuleForbiddenException();
-        }
-
-        // no registry details found, try to update
-        if(existingModule.getRegistryDetails() == null){
-            moduleService.updateRegistryDetails(existingModule);
-            moduleRepository.save(existingModule);
         }
 
         var projectId = existingModule.getRegistryDetails().getProjectId();

--- a/src/main/java/io/gaia_app/registries/AbstractRegistryApi.kt
+++ b/src/main/java/io/gaia_app/registries/AbstractRegistryApi.kt
@@ -10,30 +10,40 @@ import org.springframework.web.client.RestTemplate
 import java.net.http.HttpClient
 import java.util.*
 
-abstract class AbstractRegistryApi<K: SourceRepository>(val restTemplate: RestTemplate,
-                                                        private val registryType: RegistryType,
-                                                        private val registryFileClass: Class<K>,
-                                                        private val registryListFileClass: Class<Array<K>>): RegistryApi<K> {
+abstract class AbstractRegistryApi<K : SourceRepository>(val restTemplate: RestTemplate,
+                                                         private val registryType: RegistryType,
+                                                         private val registryFileClass: Class<K>,
+                                                         private val registryListFileClass: Class<Array<K>>) : RegistryApi<K> {
 
-    private fun <T> callWithAuth(url: String, token: String, responseType: Class<T>): T? {
+    fun <T> callWithoutAuth(url: String, responseType: Class<T>): T? {
+        try {
+            val response = restTemplate.getForEntity(
+                url,
+                responseType)
+            return response.body
+        } catch (e: HttpClientErrorException) {
+            // in case of 404, returns null as an empty body
+            return null
+        }
+    }
+
+    fun <T> callWithAuth(url: String, token: String, responseType: Class<T>): T? {
         val headers = HttpHeaders()
         headers.add("Authorization", "Bearer $token")
 
         val requestEntity = HttpEntity<Any>(headers)
 
-        try{
+        try {
             val response = restTemplate.exchange(
                 url,
                 HttpMethod.GET,
                 requestEntity,
                 responseType)
             return response.body
-        }
-        catch (e:HttpClientErrorException){
+        } catch (e: HttpClientErrorException) {
             // in case of 404, returns null as an empty body
             return null
         }
-
     }
 
     override fun getRepositories(user: User): List<K> {
@@ -43,6 +53,13 @@ abstract class AbstractRegistryApi<K: SourceRepository>(val restTemplate: RestTe
         val token = user.oAuth2User?.token!!
 
         return callWithAuth(url, token, registryListFileClass)?.toList() ?: emptyList()
+    }
+
+    override fun getRepository(projectId: String): K {
+        // fetching repositories
+        val url = registryType.repositoryUrl.format(projectId)
+
+        return callWithoutAuth(url, registryFileClass)!!
     }
 
     override fun getRepository(user: User, projectId: String): K {
@@ -57,9 +74,13 @@ abstract class AbstractRegistryApi<K: SourceRepository>(val restTemplate: RestTe
     override fun getFileContent(user: User, projectId: String, filename: String): String {
         val url = registryType.fileContentUrl.format(projectId, filename)
 
-        val token = user.oAuth2User?.token!!
+        val token = user.oAuth2User?.token
 
-        val file = callWithAuth(url, token, RegistryFile::class.java)
+        val file = if (token != null) {
+            callWithAuth(url, token, RegistryFile::class.java)
+        } else {
+            callWithoutAuth(url, RegistryFile::class.java)
+        }
 
         // removing trailing \n
         return String(Base64.getDecoder().decode(file?.content?.replace("\n", "") ?: ""))

--- a/src/main/java/io/gaia_app/registries/AbstractRegistryApi.kt
+++ b/src/main/java/io/gaia_app/registries/AbstractRegistryApi.kt
@@ -4,10 +4,8 @@ import io.gaia_app.teams.User
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
-import org.springframework.http.HttpStatus
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
-import java.net.http.HttpClient
 import java.util.*
 
 abstract class AbstractRegistryApi<K : SourceRepository>(val restTemplate: RestTemplate,

--- a/src/main/java/io/gaia_app/registries/RegistryApi.kt
+++ b/src/main/java/io/gaia_app/registries/RegistryApi.kt
@@ -6,7 +6,15 @@ interface RegistryApi<T> {
 
     fun getRepositories(user: User) : List<T>
 
+    /**
+     * Gets a repository data for an authenticated user
+     */
     fun getRepository(user: User, projectId: String): T
+
+    /**
+     * Gets a repository data for an anonymous user
+     */
+    fun getRepository(projectId: String): T
 
     fun getFileContent(user: User, projectId: String, filename: String): String
 

--- a/src/main/java/io/gaia_app/registries/gitlab/GitlabRegistryApi.kt
+++ b/src/main/java/io/gaia_app/registries/gitlab/GitlabRegistryApi.kt
@@ -6,13 +6,20 @@ import io.gaia_app.registries.RegistryType
 import io.gaia_app.registries.SourceRepository
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestTemplate
+import java.net.URLEncoder
+import java.nio.charset.Charset
 
 @Service
 class GitlabRegistryApi(restTemplate: RestTemplate): AbstractRegistryApi<GitlabRepository>(
         restTemplate,
         RegistryType.GITLAB,
         GitlabRepository::class.java,
-        Array<GitlabRepository>::class.java)
+        Array<GitlabRepository>::class.java) {
+
+    override fun getRepository(projectId: String): GitlabRepository {
+        return super.getRepository(URLEncoder.encode(projectId, Charset.defaultCharset()))
+    }
+}
 
 /**
  * Gitlab source repository implementation

--- a/src/main/java/io/gaia_app/runner/RunnerController.java
+++ b/src/main/java/io/gaia_app/runner/RunnerController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 

--- a/src/test/java/io/gaia_app/modules/ModuleServiceImplTest.java
+++ b/src/test/java/io/gaia_app/modules/ModuleServiceImplTest.java
@@ -1,0 +1,42 @@
+package io.gaia_app.modules;
+
+import io.gaia_app.modules.bo.TerraformModule;
+import io.gaia_app.registries.RegistryType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ModuleServiceImplTest {
+
+    public static Stream<String> updateRegistryDetails_forGithubModule() {
+        return Stream.of(
+            "https://github.com/juwit/terraform-docker-mongo",
+            "https://github.com/juwit/terraform-docker-mongo.git",
+            "git@github.com:juwit/terraform-docker-mongo",
+            "git@github.com:juwit/terraform-docker-mongo.git"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void updateRegistryDetails_forGithubModule(String registryUrl) {
+        var module = new TerraformModule();
+        module.setGitRepositoryUrl(registryUrl);
+
+        var moduleService = new ModuleServiceImpl();
+        moduleService.updateRegistryDetails(module);
+
+        assertThat(module.getRegistryDetails())
+            .isNotNull()
+            .satisfies(it -> {
+                assertThat(it.getRegistryType()).isEqualTo(RegistryType.GITHUB);
+                assertThat(it.getProjectId()).isEqualTo("juwit/terraform-docker-mongo");
+            });
+    }
+}

--- a/src/test/java/io/gaia_app/modules/ModuleServiceImplTest.java
+++ b/src/test/java/io/gaia_app/modules/ModuleServiceImplTest.java
@@ -2,17 +2,33 @@ package io.gaia_app.modules;
 
 import io.gaia_app.modules.bo.TerraformModule;
 import io.gaia_app.registries.RegistryType;
-import org.junit.jupiter.api.Test;
+import io.gaia_app.registries.github.GithubRegistryApi;
+import io.gaia_app.registries.github.GithubRepository;
+import io.gaia_app.registries.gitlab.GitlabRegistryApi;
+import io.gaia_app.registries.gitlab.GitlabRepository;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class ModuleServiceImplTest {
+
+    @Mock
+    private GitlabRegistryApi gitlabRegistryApi;
+
+    @Mock
+    private GithubRegistryApi githubRegistryApi;
+
+    @InjectMocks
+    private ModuleServiceImpl moduleService;
 
     public static Stream<String> updateRegistryDetails_forGithubModule() {
         return Stream.of(
@@ -26,10 +42,11 @@ class ModuleServiceImplTest {
     @ParameterizedTest
     @MethodSource
     void updateRegistryDetails_forGithubModule(String registryUrl) {
+        when(githubRegistryApi.getRepository("juwit/terraform-docker-mongo")).thenReturn(new GithubRepository("juwit/terraform-docker-mongo", ""));
+
         var module = new TerraformModule();
         module.setGitRepositoryUrl(registryUrl);
 
-        var moduleService = new ModuleServiceImpl();
         moduleService.updateRegistryDetails(module);
 
         assertThat(module.getRegistryDetails())
@@ -37,6 +54,34 @@ class ModuleServiceImplTest {
             .satisfies(it -> {
                 assertThat(it.getRegistryType()).isEqualTo(RegistryType.GITHUB);
                 assertThat(it.getProjectId()).isEqualTo("juwit/terraform-docker-mongo");
+            });
+    }
+
+    public static Stream<String> updateRegistryDetails_forGitlabModule() {
+        return Stream.of(
+            "https://gitlab.com/juwit/terraform-docker-mongo",
+            "https://gitlab.com/juwit/terraform-docker-mongo/",
+            "https://gitlab.com/juwit/terraform-docker-mongo.git",
+            "git@gitlab.com:juwit/terraform-docker-mongo",
+            "git@gitlab.com:juwit/terraform-docker-mongo.git"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void updateRegistryDetails_forGitlabModule(String registryUrl) {
+        when(gitlabRegistryApi.getRepository("juwit/terraform-docker-mongo")).thenReturn(new GitlabRepository("16181047", "", ""));
+
+        var module = new TerraformModule();
+        module.setGitRepositoryUrl(registryUrl);
+
+        moduleService.updateRegistryDetails(module);
+
+        assertThat(module.getRegistryDetails())
+            .isNotNull()
+            .satisfies(it -> {
+                assertThat(it.getRegistryType()).isEqualTo(RegistryType.GITLAB);
+                assertThat(it.getProjectId()).isEqualTo("16181047");
             });
     }
 }

--- a/src/test/java/io/gaia_app/modules/controller/ModuleRestControllerTest.java
+++ b/src/test/java/io/gaia_app/modules/controller/ModuleRestControllerTest.java
@@ -1,5 +1,6 @@
 package io.gaia_app.modules.controller;
 
+import io.gaia_app.modules.ModuleService;
 import io.gaia_app.modules.repository.TerraformModuleGitRepository;
 import io.gaia_app.modules.repository.TerraformModuleRepository;
 import io.gaia_app.registries.RegistryDetails;
@@ -39,6 +40,9 @@ class ModuleRestControllerTest {
 
     @Mock
     private RegistryService registryService;
+
+    @Mock
+    private ModuleService moduleService;
 
     private User admin;
 


### PR DESCRIPTION
## Description

This PR allows module refresh for manually imported modules by analysing the module URL to determine the registry/projet id (especially for gitlab project ids).

## Checklist for the pull request author

- [x] Tests added for this feature
- [x] Commit messages follow conventions (see [CONTRIBUTING.md](CONTRIBUTING.md))
- [x] Commits are combined ( 1 commit / type and scope )
- [x] Documentation created / updated (if necessary)
- [x] No new sonarqube issues added
- [x] CI pipeline is OK
- [x] Pull request is fast-forward to the `main` branch
- [x] The last commit of this merge request :
    - [x] updates the `pom.xml` to a new minor or major version
    - [x] updates the `CHANGELOG.md`

## Checklist for the project maintainer

- [ ] Review the code, and add a *Review Approval* if everything is ok
- [ ] This pull request will be merged in merge-commit mode
    - (in github or with the CLI, see [CONTRIBUTING.md](CONTRIBUTING.md))

### After the merge

- [ ] Put the tag on the merged commit
    - (in github or with the CLI, see [CONTRIBUTING.md](CONTRIBUTING.md))
- [ ] Follow the pipeline for the tag, which should build & release the package (maven or docker)

## Issues / Links

* resolves #688 

